### PR TITLE
Adding version number to manifest

### DIFF
--- a/custom_components/ziggonext/manifest.json
+++ b/custom_components/ziggonext/manifest.json
@@ -7,5 +7,5 @@
   ],
   "dependencies": [],
   "codeowners": ["@Sholofly"],
-  "version": "0.7.9"
+  "version": "0.7.10"
 }

--- a/custom_components/ziggonext/manifest.json
+++ b/custom_components/ziggonext/manifest.json
@@ -6,5 +6,6 @@
     "ziggonext==0.10.9"
   ],
   "dependencies": [],
-  "codeowners": ["@Sholofly"]
+  "codeowners": ["@Sholofly"],
+  "version": "0.7.9"
 }


### PR DESCRIPTION
Fixes warning:
```
2021-03-04 11:35:05 WARNING (MainThread) [homeassistant.loader] No 'version' key in the manifest file for custom integration 'ziggonext'. This will not be allowed in a future version of Home Assistant. Please report this to the maintainer of 'ziggonext'
```